### PR TITLE
[feat] Support search dingo-eureka by find_package with version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,11 +15,29 @@
 cmake_minimum_required(VERSION 3.23.1 FATAL_ERROR)
 project(dingo-eureka C CXX)
 
+# dingo-eureka version
+set(DINGOEUREKA_VERSION 1.0)
+
 # third-party install path
 if(NOT INSTALL_PATH)
     set(INSTALL_PATH "$ENV{HOME}/.local/dingo-eureka")
 endif()
 message("INSTALL_PATH:${INSTALL_PATH}")
+
+# generated version file
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/dingoEurekaConfigVersion.cmake.in
+    ${CMAKE_BINARY_DIR}/cmake/dingoEurekaConfigVersion.cmake
+    @ONLY
+)
+file(WRITE ${CMAKE_BINARY_DIR}/cmake/dingoEurekaConfig.cmake "#This file is mainly used to search dingo-eureka by find_package, do not delete it") 
+# copy dingo-eureka cmake version file
+file(COPY 
+    ${CMAKE_BINARY_DIR}/cmake/dingoEurekaConfig.cmake
+    ${CMAKE_BINARY_DIR}/cmake/dingoEurekaConfigVersion.cmake
+    DESTINATION ${INSTALL_PATH}/cmake
+)
+message(STATUS "dingo-eureka cmake version file: ${INSTALL_PATH}/cmake/dingoEurekaConfigVersion.cmake")
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo")

--- a/dingoEurekaConfigVersion.cmake.in
+++ b/dingoEurekaConfigVersion.cmake.in
@@ -1,0 +1,35 @@
+# version
+set(PACKAGE_VERSION "@DINGOEUREKA_VERSION@")
+
+if(NOT PACKAGE_FIND_VERSION)
+    set(PACKAGE_FIND_VERSION ${PACKAGE_VERSION})
+endif()
+
+string(REPLACE "." ";" VERSION_LIST ${PACKAGE_VERSION})
+#  actual major version
+list(GET VERSION_LIST 0 MAJOR_VERSION)
+#  actual minor version
+list(GET VERSION_LIST 1 MINOR_VERSION)
+message(STATUS "actual dingo-eureka major version ${MAJOR_VERSION}")
+message(STATUS "actual dingo-eureka minor version ${MINOR_VERSION}")
+
+string(REPLACE "." ";" FIND_VERSION_LIST ${PACKAGE_FIND_VERSION})
+#  find major version
+list(GET FIND_VERSION_LIST 0 FIND_MAJOR_VERSION)
+#  find minor version
+list(GET FIND_VERSION_LIST 1 FIND_MINOR_VERSION)
+message(STATUS "Found dingo-eureka major version ${FIND_MAJOR_VERSION}")
+message(STATUS "Found dingo-eureka minor version ${FIND_MINOR_VERSION}")
+
+# 1.x compatible 1.y (x>=y)
+if(FIND_MAJOR_VERSION EQUAL MAJOR_VERSION AND FIND_MINOR_VERSION LESS_EQUAL MINOR_VERSION)
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+else()
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+endif()
+
+if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+    set(PACKAGE_VERSION_EXACT TRUE) 
+endif()
+
+message(STATUS "Found dingo-eureka version ${PACKAGE_VERSION}")


### PR DESCRIPTION
assuming the third-party library dingoEureka version is 1.5

Usage ：

**exact version matching:**
find_package(dingoEureka 1.5 EXACT REQUIRED) success
find_package(dingoEureka 1.0 EXACT REQUIRED) fail

**backward compatible:**
find_package(dingoEureka 0.9  REQUIRED)  fail
find_package(dingoEureka 1.1  REQUIRED)  success
find_package(dingoEureka 1.6  REQUIRED)  fail
find_package(dingoEureka 2.0  REQUIRED)  fail